### PR TITLE
test: update pattern for commits to include dependabot

### DIFF
--- a/.github/workflows/commit_msg.yml
+++ b/.github/workflows/commit_msg.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Check Commit Format
         uses: gsactions/commit-message-checker@v1
         with:
-          pattern: '^((docs|feat|fix|refactor|style|test|sweep)( ?\(.*\))?: .+|Revert ".+")$'
+          pattern: '^((docs|feat|fix|refactor|style|test|sweep|build)( ?\(.*\))?: .+|Revert ".+")$'
           excludeDescription: 'true' # optional: this excludes the description body of a pull request
           excludeTitle: 'true' # optional: this excludes the title of a pull request
           checkAllCommitMessages: 'true' # optional: this checks all commits associated with a pull request


### PR DESCRIPTION
Current pattern for commits excludes dependabots commits messages (see example in #7).
This PR fixes that.