### PR TITLE
Fixing #38: Templates for JDL and submit cmd

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dynamic = ["version"]
 dependencies = [
     "dask",
     "dask_jobqueue",
+    "jinja2",
     "requests",
     "typer",
 ]

--- a/src/dask_dirac/_dask.py
+++ b/src/dask_dirac/_dask.py
@@ -24,6 +24,13 @@ def _get_site_ports(site: str) -> str:
     return " "  # None
 
 
+def _create_tmp_jdl_path() -> str:
+    return (
+        "/tmp/dask-dirac-JDL_"
+        + hashlib.sha1(getpass.getuser().encode("utf-8")).hexdigest()[:8]
+    )
+
+
 class DiracJob(Job):
     """Job class for Dirac"""
 
@@ -34,32 +41,17 @@ class DiracJob(Job):
         scheduler: Any = None,
         name: str | None = None,
         config_name: str | None = None,
-        submission_url: str | None = None,
-        user_proxy: str | None = None,
-        cert_path: str | None = None,
-        jdl_file: str | None = None,
-        owner_group: str | None = None,
+        submission_url: str = "https://lbcertifdirac70.cern.ch:8443",
+        user_proxy: str = "/tmp/x509up_u1000",
+        cert_path: str = "/etc/grid-security/certificates",
+        jdl_file: str = _create_tmp_jdl_path(),
+        owner_group: str = "dteam_user",
         dirac_site: str | None = None,
         **base_class_kwargs: dict[str, Any],
     ) -> None:
         super().__init__(
             scheduler=scheduler, name=name, config_name=config_name, **base_class_kwargs
         )
-
-        if submission_url is None:
-            submission_url = "https://lbcertifdirac70.cern.ch:8443"
-        if user_proxy is None:
-            user_proxy = "/tmp/x509up_u1000"
-        if jdl_file is None:
-            jdl_file = (
-                "/tmp/dask-dirac-JDL_"
-                + hashlib.sha1(getpass.getuser().encode("utf-8")).hexdigest()[:8]
-            )
-        if cert_path is None:
-            cert_path = "/etc/grid-security/certificates"
-        if owner_group is None:
-            owner_group = "dteam_user"
-
         # public_address = get("https://ifconfig.me", timeout=30).content.decode("utf8")
         public_address = get("https://v4.ident.me/", timeout=30).content.decode("utf8")
         container = "docker://sameriksen/dask:centos9"

--- a/src/dask_dirac/_dask.py
+++ b/src/dask_dirac/_dask.py
@@ -17,8 +17,8 @@ from .templates import get_template
 logger = logging.getLogger(__name__)
 
 
-def _get_site_ports(site: str) -> str:
-    if site == "LCG.UKI-SOUTHGRID-RALPP.uk":
+def _get_site_ports(sites: list[str]) -> str:
+    if "LCG.UKI-SOUTHGRID-RALPP.uk" in sites:
         return " --worker-port 50000:52000"
 
     return " "  # None
@@ -46,7 +46,7 @@ class DiracJob(Job):
         cert_path: str = "/etc/grid-security/certificates",
         jdl_file: str = _create_tmp_jdl_path(),
         owner_group: str = "dteam_user",
-        dirac_site: str | None = None,
+        dirac_sites: list[str] | None = None,
         **base_class_kwargs: dict[str, Any],
     ) -> None:
         super().__init__(
@@ -57,13 +57,13 @@ class DiracJob(Job):
         container = "docker://sameriksen/dask:centos9"
         jdl_template = get_template("jdl.j2")
 
-        extra_args = _get_site_ports(dirac_site) if dirac_site else ""
+        extra_args = _get_site_ports(dirac_sites) if dirac_sites else ""
 
         rendered_jdl = jdl_template.render(
             container=container,
             public_address=public_address,
             owner=owner_group,
-            dirac_site=dirac_site,
+            dirac_sites=dirac_sites,
             extra_args=extra_args,
         )
 

--- a/src/dask_dirac/_dask.py
+++ b/src/dask_dirac/_dask.py
@@ -63,10 +63,12 @@ class DiracJob(Job):
         # public_address = get("https://ifconfig.me", timeout=30).content.decode("utf8")
         public_address = get("https://v4.ident.me/", timeout=30).content.decode("utf8")
         container = "docker://sameriksen/dask:centos9"
-        singularity_args = f"exec --cleanenv --bind /cvmfs:/cvmfs {container} dask worker tcp://{public_address}:8786"
         jdl_template = get_template("jdl.j2")
         rendered_jdl = jdl_template.render(
-            executable_args=singularity_args, owner=owner_group, dirac_site=dirac_site
+            container=container,
+            public_address=public_address,
+            owner=owner_group,
+            dirac_site=dirac_site,
         )
 
         # Write JDL

--- a/src/dask_dirac/templates/__init__.py
+++ b/src/dask_dirac/templates/__init__.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from jinja2 import Environment, PackageLoader, Template, select_autoescape
+
+env = None
+
+
+def get_jinja_env() -> Environment:
+    global env
+    if env is None:
+        env = Environment(
+            loader=PackageLoader("dask_dirac"), autoescape=select_autoescape()
+        )
+    return env
+
+
+def get_template(template_name: str) -> Template:
+    return get_jinja_env().get_template(template_name)

--- a/src/dask_dirac/templates/jdl.j2
+++ b/src/dask_dirac/templates/jdl.j2
@@ -6,6 +6,6 @@ StdError = "std.err";
 OutputSandbox = {"std.out","std.err"};
 OwnerGroup = {{ owner }};
 
-{% if dirac_site %}
-Site = "{{ dirac_site }}";
+{% if dirac_sites %}
+Site = "{{ dirac_sites | join(', ') }}";
 {% endif %}

--- a/src/dask_dirac/templates/jdl.j2
+++ b/src/dask_dirac/templates/jdl.j2
@@ -1,6 +1,6 @@
 JobName = "dask-dirac: dask worker";
 Executable = "singularity";
-Arguments = "{{ executable_args }}";
+Arguments = "exec --cleanenv --bind /cvmfs:/cvmfs {{ container }} dask worker tcp://{{ public_address }}:8786";
 StdOutput = "std.out";
 StdError = "std.err";
 OutputSandbox = {"std.out","std.err"};

--- a/src/dask_dirac/templates/jdl.j2
+++ b/src/dask_dirac/templates/jdl.j2
@@ -1,0 +1,11 @@
+JobName = "dask-dirac: dask worker";
+Executable = "singularity";
+Arguments = "{{ executable_args }}";
+StdOutput = "std.out";
+StdError = "std.err";
+OutputSandbox = {"std.out","std.err"};
+OwnerGroup = {{ owner }};
+
+{% if dirac_site %}
+Site = "{{ dirac_site }}";
+{% endif %}

--- a/src/dask_dirac/templates/jdl.j2
+++ b/src/dask_dirac/templates/jdl.j2
@@ -1,6 +1,6 @@
 JobName = "dask-dirac: dask worker";
 Executable = "singularity";
-Arguments = "exec --cleanenv --bind /cvmfs:/cvmfs {{ container }} dask worker tcp://{{ public_address }}:8786";
+Arguments = "exec --cleanenv --bind /cvmfs:/cvmfs {{ container }} dask worker tcp://{{ public_address }}:8786 {% if extra_args -%}{{extra_args}}{%endif -%}";
 StdOutput = "std.out";
 StdError = "std.err";
 OutputSandbox = {"std.out","std.err"};

--- a/src/dask_dirac/templates/submit_command.j2
+++ b/src/dask_dirac/templates/submit_command.j2
@@ -1,0 +1,1 @@
+dask-dirac submit {{ submission_url }} {{ jdl_file }} --capath {{ cert_path }} --user-proxy {{ user_proxy }} --dask-script

--- a/tests/templates/test_jdl.py
+++ b/tests/templates/test_jdl.py
@@ -13,6 +13,8 @@ def jinja_env():
 def test_jdl_template_rendering(jinja_env):
     # Prepare test data
     test_executable_args = "test_args"
+    test_container = "python:3.11"
+    test_public_address = "127.0.0.1"
     test_owner_group = "test_group"
     test_dirac_site = "test_site"
 
@@ -21,13 +23,15 @@ def test_jdl_template_rendering(jinja_env):
 
     # Render the template
     result = template.render(
-        executable_args=test_executable_args,
+        container=test_container,
+        public_address=test_public_address,
         owner=test_owner_group,
         dirac_site=test_dirac_site,
     )
 
     # Assertions
-    assert 'Arguments = "test_args"' in result
+    assert test_container in result
+    assert test_public_address in result
     assert "OwnerGroup = test_group" in result
     assert 'Site = "test_site"' in result
 

--- a/tests/templates/test_jdl.py
+++ b/tests/templates/test_jdl.py
@@ -16,7 +16,7 @@ def test_jdl_template_rendering(jinja_env):
     test_container = "python:3.11"
     test_public_address = "127.0.0.1"
     test_owner_group = "test_group"
-    test_dirac_site = "test_site"
+    test_dirac_sites = ["test_site1", "test_site2"]
 
     # Load the template
     template = jinja_env.get_template("jdl.j2")
@@ -26,14 +26,14 @@ def test_jdl_template_rendering(jinja_env):
         container=test_container,
         public_address=test_public_address,
         owner=test_owner_group,
-        dirac_site=test_dirac_site,
+        dirac_sites=test_dirac_sites,
     )
 
     # Assertions
     assert test_container in result
     assert test_public_address in result
     assert "OwnerGroup = test_group" in result
-    assert 'Site = "test_site"' in result
+    assert 'Site = "test_site1, test_site2"' in result
 
     # Test without dirac_site
     result_no_site = template.render(

--- a/tests/templates/test_jdl.py
+++ b/tests/templates/test_jdl.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import pytest
+
+import dask_dirac.templates as templates
+
+
+@pytest.fixture
+def jinja_env():
+    return templates.get_jinja_env()
+
+
+def test_jdl_template_rendering(jinja_env):
+    # Prepare test data
+    test_executable_args = "test_args"
+    test_owner_group = "test_group"
+    test_dirac_site = "test_site"
+
+    # Load the template
+    template = jinja_env.get_template("jdl.j2")
+
+    # Render the template
+    result = template.render(
+        executable_args=test_executable_args,
+        owner=test_owner_group,
+        dirac_site=test_dirac_site,
+    )
+
+    # Assertions
+    assert 'Arguments = "test_args"' in result
+    assert "OwnerGroup = test_group" in result
+    assert 'Site = "test_site"' in result
+
+    # Test without dirac_site
+    result_no_site = template.render(
+        executable_args=test_executable_args, owner=test_owner_group, dirac_site=None
+    )
+    assert "Site =" not in result_no_site

--- a/tests/templates/test_jdl.py
+++ b/tests/templates/test_jdl.py
@@ -37,6 +37,38 @@ def test_jdl_template_rendering(jinja_env):
 
     # Test without dirac_site
     result_no_site = template.render(
-        executable_args=test_executable_args, owner=test_owner_group, dirac_site=None
+        executable_args=test_executable_args, owner=test_owner_group
     )
     assert "Site =" not in result_no_site
+
+    # test with extra_args
+    test_extra_args = "--nooop"
+    result_extra_args = template.render(
+        executable_args=test_executable_args,
+        owner=test_owner_group,
+        extra_args=test_extra_args,
+    )
+    assert test_extra_args in result_extra_args
+
+
+def test_submit_command_template_rendering(jinja_env):
+    # Prepare test data
+    test_submission_url = "test_url"
+    test_jdl_file = "test_jdl_file"
+    test_cert_path = "test_cert_path"
+    test_user_proxy = "test_user_proxy"
+
+    # Load the template
+    template = jinja_env.get_template("submit_command.j2")
+
+    # Render the template
+    result = template.render(
+        submission_url=test_submission_url,
+        jdl_file=test_jdl_file,
+        cert_path=test_cert_path,
+        user_proxy=test_user_proxy,
+    )
+
+    # Assertions
+    expected_command = "dask-dirac submit test_url test_jdl_file --capath test_cert_path --user-proxy test_user_proxy --dask-script"
+    assert result.strip() == expected_command


### PR DESCRIPTION
This PR 
- introduces Jinja2 templates for the JDL and submit command.
- allows for multiple sites to be specified
- cleanup of default values